### PR TITLE
Specify ContentType when uploading to S3

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ const action = async context => {
 	const bucket = split.shift();
 	const filename = path.basename(filePath);
 	const extension = path.extname(filename);
-	let contentType = 'application/octet-stream';
 
+	let contentType = 'application/octet-stream';
 	switch (extension) {
 		case '.gif':
 			contentType = 'image/gif';

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const action = async context => {
 	const extension = path.extname(filename);
 	let contentType = 'application/octet-stream';
 
-	switch (extension){
+	switch (extension) {
 		case '.gif':
 			contentType = 'image/gif';
 			break;

--- a/index.js
+++ b/index.js
@@ -17,11 +17,29 @@ const action = async context => {
 	const split = context.config.get('path').split('/');
 	const bucket = split.shift();
 	const filename = path.basename(filePath);
-
+	const extension = path.extname(filename);
+	const contentType = 'application/octet-stream';
+	
+	switch (extension) {
+		case '.gif':
+			contentType = 'image/gif';
+			break;
+		case '.mp4':
+			contentType = 'video/mp4';
+			break;
+		case '.webm':
+			contentType = 'video/webm';
+			break;
+		case '.apng':
+			contentType = 'image/apng';
+			break;
+	}	
+	
 	const upload = s3.upload({
 		Bucket: bucket,
 		Key: path.join(split.join('/'), filename),
-		Body: fs.createReadStream(filePath)
+		Body: fs.createReadStream(filePath),
+		ContentType: contentType
 	});
 
 	upload.on('httpUploadProgress', progress => {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const action = async context => {
 	const filename = path.basename(filePath);
 	const extension = path.extname(filename);
 	let contentType = 'application/octet-stream';
-	
-	switch (extension) {
+
+	switch(extension) {
 		case '.gif':
 			contentType = 'image/gif';
 			break;
@@ -32,6 +32,9 @@ const action = async context => {
 			break;
 		case '.apng':
 			contentType = 'image/apng';
+			break;
+		default:
+			contentType = 'application/octet-stream';
 			break;
 	}
 	

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const action = async context => {
 	const extension = path.extname(filename);
 	let contentType = 'application/octet-stream';
 
-	switch(extension) {
+	switch (extension){
 		case '.gif':
 			contentType = 'image/gif';
 			break;
@@ -37,7 +37,7 @@ const action = async context => {
 			contentType = 'application/octet-stream';
 			break;
 	}
-	
+
 	const upload = s3.upload({
 		Bucket: bucket,
 		Key: path.join(split.join('/'), filename),

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const action = async context => {
 		case '.apng':
 			contentType = 'image/apng';
 			break;
-	}	
+	}
 	
 	const upload = s3.upload({
 		Bucket: bucket,

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const action = async context => {
 	const bucket = split.shift();
 	const filename = path.basename(filePath);
 	const extension = path.extname(filename);
-	const contentType = 'application/octet-stream';
+	let contentType = 'application/octet-stream';
 	
 	switch (extension) {
 		case '.gif':

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ test('s3 upload parameters are correct', async t => {
 
 	t.is(s3UploadParams.Bucket, 'bucket');
 	t.is(s3UploadParams.Key, 'folder/unicorn.gif');
+	t.is(s3UploadParams.ContentType, 'image/gif');
 });
 
 test('copies url to clipboard', async t => {


### PR DESCRIPTION
Specify correct ContentType, based on file extension, when uploading to S3.  Otherwise, it will default to application/octet-stream and force a file to be downloaded rather than shown in browser.