### PR TITLE
ContentType and baseURL support

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const action = async context => {
 	const extension = path.extname(filename);
 	let contentType = 'application/octet-stream';
 
-	switch (extension){
+	switch (extension) {
 		case '.gif':
 			contentType = 'image/gif';
 			break;

--- a/index.js
+++ b/index.js
@@ -17,11 +17,29 @@ const action = async context => {
 	const split = context.config.get('path').split('/');
 	const bucket = split.shift();
 	const filename = path.basename(filePath);
-
+	const extension = path.extname(filename);
+	const contentType = 'application/octet-stream';
+	
+	switch (extension) {
+		case '.gif':
+			contentType = 'image/gif';
+			break;
+		case '.mp4':
+			contentType = 'video/mp4';
+			break;
+		case '.webm':
+			contentType = 'video/webm';
+			break;
+		case '.apng':
+			contentType = 'image/apng';
+			break;
+	}	
+	
 	const upload = s3.upload({
 		Bucket: bucket,
 		Key: path.join(split.join('/'), filename),
-		Body: fs.createReadStream(filePath)
+		Body: fs.createReadStream(filePath),
+		ContentType: contentType
 	});
 
 	upload.on('httpUploadProgress', progress => {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const action = async context => {
 	const filename = path.basename(filePath);
 	const extension = path.extname(filename);
 	let contentType = 'application/octet-stream';
-	
-	switch (extension) {
+
+	switch(extension) {
 		case '.gif':
 			contentType = 'image/gif';
 			break;
@@ -32,6 +32,9 @@ const action = async context => {
 			break;
 		case '.apng':
 			contentType = 'image/apng';
+			break;
+		default:
+			contentType = 'application/octet-stream';
 			break;
 	}
 	

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const action = async context => {
 	const extension = path.extname(filename);
 	let contentType = 'application/octet-stream';
 
-	switch(extension) {
+	switch (extension){
 		case '.gif':
 			contentType = 'image/gif';
 			break;
@@ -37,7 +37,7 @@ const action = async context => {
 			contentType = 'application/octet-stream';
 			break;
 	}
-	
+
 	const upload = s3.upload({
 		Bucket: bucket,
 		Key: path.join(split.join('/'), filename),

--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ const action = async context => {
 	let uploadURL = response.Location;
 
 	const baseURL = context.config.get('baseURL');
-	console.log('baseURL' + baseURL);
 	if (baseURL) {
 		uploadURL = url.resolve(baseURL, objectKey);
 	}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@ const path = require('path');
 const url = require('url');
 const AWS = require('aws-sdk');
 
+const contentTypes = new Map([
+	['.gif', 'image/gif'],
+	['.mp4', 'video/mp4'],
+	['.webm', 'video/webm'],
+	['.apng', 'image/apng']
+]);
+
 const action = async context => {
 	const filePath = await context.filePath();
 
@@ -20,14 +27,6 @@ const action = async context => {
 	const filename = path.basename(filePath);
 	const extension = path.extname(filename);
 	const objectKey = path.join(split.join('/'), filename);
-
-	const contentTypes = new Map([
-		['.gif', 'image/gif'],
-		['.mp4', 'video/mp4'],
-		['.webm', 'video/webm'],
-		['.apng', 'image/apng']
-	]);
-
 	const contentType = contentTypes.get(extension) || 'application/octet-stream';
 
 	const upload = s3.upload({

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const action = async context => {
 		case '.apng':
 			contentType = 'image/apng';
 			break;
-	}	
+	}
 	
 	const upload = s3.upload({
 		Bucket: bucket,

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const action = async context => {
 	const bucket = split.shift();
 	const filename = path.basename(filePath);
 	const extension = path.extname(filename);
-	const contentType = 'application/octet-stream';
+	let contentType = 'application/octet-stream';
 	
 	switch (extension) {
 		case '.gif':

--- a/index.js
+++ b/index.js
@@ -21,24 +21,14 @@ const action = async context => {
 	const extension = path.extname(filename);
 	const objectKey = path.join(split.join('/'), filename);
 
-	let contentType = 'application/octet-stream';
-	switch (extension) {
-		case '.gif':
-			contentType = 'image/gif';
-			break;
-		case '.mp4':
-			contentType = 'video/mp4';
-			break;
-		case '.webm':
-			contentType = 'video/webm';
-			break;
-		case '.apng':
-			contentType = 'image/apng';
-			break;
-		default:
-			contentType = 'application/octet-stream';
-			break;
-	}
+	const contentTypes = new Map([
+		['.gif', 'image/gif'],
+		['.mp4', 'video/mp4'],
+		['.webm', 'video/webm'],
+		['.apng', 'image/apng']
+	]);
+
+	const contentType = contentTypes.get(extension) || 'application/octet-stream';
 
 	const upload = s3.upload({
 		Bucket: bucket,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/SamVerschueren"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "npx xo && npx ava"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/SamVerschueren"
   },
   "scripts": {
-    "test": "npx xo && npx ava"
+    "test": "xo && ava"
   },
   "files": [
     "index.js"

--- a/test/test.js
+++ b/test/test.js
@@ -32,3 +32,13 @@ test('copies url to clipboard', async t => {
 
 	t.true(plugin.context.copyToClipboard.calledWith('https://s3-eu-west-1.amazonaws.com/bucket/folder/unicorn.gif'));
 });
+
+test('uses baseURL config correctly', async t => {
+	const testConfig = {config};
+	testConfig.config.baseURL = 'https://mydomain.com/';
+	const plugin = pluginTest(file, testConfig);
+
+	await plugin.run();
+
+	t.true(plugin.context.copyToClipboard.calledWith('https://mydomain.com/folder/unicorn.gif'));
+});

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ test('s3 upload parameters are correct', async t => {
 
 	t.is(s3UploadParams.Bucket, 'bucket');
 	t.is(s3UploadParams.Key, 'folder/unicorn.gif');
+	t.is(s3UploadParams.ContentType, 'image/gif');
 });
 
 test('copies url to clipboard', async t => {


### PR DESCRIPTION
- Specify correct ContentType, based on file extension, when uploading to S3. Otherwise, it will default to application/octet-stream and force a file to be downloaded rather than shown in browser.
- Add support for `baseURL` config to **support custom domains**.  Not a required config, but if specified, the URL copied to the clipboard will use baseURL as a prefix rather than the S3 endpoint URL (http://s3*.amazonaws.com).  This allows custom domains to be used so that if you have a bucket named www.mydomain.com setup and a DNS CNAME  from www.mydomain.com to S3, specifying the following config:

  ```
  "path": "www.mydomain.com/kap",
  "baseURL": "https://www.mydomain.com/kap"
  ```

  would result in the URL copied to clipboard being formatted as 
  "https://www.mydomain.com/kap/[imagename.png]"