### PR TITLE
Specify ContentType when uploading to S3

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ const fs = require('fs');
 const path = require('path');
 const AWS = require('aws-sdk');
 
+const contentTypes = new Map([
+	['.gif', 'image/gif'],
+	['.mp4', 'video/mp4'],
+	['.webm', 'video/webm'],
+	['.apng', 'image/apng']
+]);
+
 const action = async context => {
 	const filePath = await context.filePath();
 
@@ -17,11 +24,14 @@ const action = async context => {
 	const split = context.config.get('path').split('/');
 	const bucket = split.shift();
 	const filename = path.basename(filePath);
+	const extension = path.extname(filename);
+	const contentType = contentTypes.get(extension) || 'application/octet-stream';
 
 	const upload = s3.upload({
 		Bucket: bucket,
 		Key: path.join(split.join('/'), filename),
-		Body: fs.createReadStream(filePath)
+		Body: fs.createReadStream(filePath),
+		ContentType: contentType
 	});
 
 	upload.on('httpUploadProgress', progress => {

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ test('s3 upload parameters are correct', async t => {
 
 	t.is(s3UploadParams.Bucket, 'bucket');
 	t.is(s3UploadParams.Key, 'folder/unicorn.gif');
+	t.is(s3UploadParams.ContentType, 'image/gif');
 });
 
 test('copies url to clipboard', async t => {


### PR DESCRIPTION
Specify correct ContentType, based on file extension, when uploading to S3. Otherwise, it will default to application/octet-stream and force a file to be downloaded rather than shown in browser.