### PR TITLE
Add baseURL config for custom domains support

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -32,3 +32,13 @@ test('copies url to clipboard', async t => {
 
 	t.true(plugin.context.copyToClipboard.calledWith('https://s3-eu-west-1.amazonaws.com/bucket/folder/unicorn.gif'));
 });
+
+test('uses baseURL config correctly', async t => {
+	const testConfig = {config};
+	testConfig.config.baseURL = 'https://mydomain.com/';
+	const plugin = pluginTest(file, testConfig);
+
+	await plugin.run();
+
+	t.true(plugin.context.copyToClipboard.calledWith('https://mydomain.com/folder/unicorn.gif'));
+});


### PR DESCRIPTION
This adds a new config called `baseURL`.

`baseURL` **allows support of custom domains** pointing to S3.  So, if I setup a S3 bucket and a custom domain pointing to it, with a `baseURL` config, the URLs generated and copied to the clipboard will use this custom domain.  

### Example

Following the Amazon guide about [custom domains on S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html),  I have the domain media.geekytidbits.com which is a CNAME to s3.amazonaws.com.

![image](https://user-images.githubusercontent.com/759811/37769249-602c4aa0-2d9e-11e8-8e17-956bc13a7853.png)

I also have a S3 bucket named media.geekytidbits.com:

![image](https://user-images.githubusercontent.com/759811/37769279-7c3eb566-2d9e-11e8-97bd-a92ac687d00a.png)

Now, anything added to this bucket is available at https://media.geekytidbits.com/*.  So, if I drop image.jpg in the bucket, it's available at https://media.geekytidbits.com/image.jpg.

Using these changes, my kap-s3 config looks like the following, which allows my custom domain to be used:

```
{
	"region": "us-east-1",
	"accessKeyId": "[redacted]",
	"secretAccessKey": "[redacted]",
	"path": "media.geekytidbits.com/",
	"baseURL": "https://media.geekytidbits.com"
}
```

[Monosnap](http://monosnap.com/) has a Base URL config and my setup looks like this:

![image](https://user-images.githubusercontent.com/759811/37769421-ec0b5fe8-2d9e-11e8-99aa-029a13aa552b.png)
