### PR TITLE
Allow for configuring S3 object ACL

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,12 +28,14 @@ const action = async context => {
 	const objectKey = path.join(split.join('/'), filename);
 	const extension = path.extname(filename);
 	const contentType = contentTypes.get(extension) || 'application/octet-stream';
+	const acl = context.config.get('acl');
 
 	const upload = s3.upload({
 		Bucket: bucket,
 		Key: path.join(split.join('/'), filename),
 		Body: fs.createReadStream(filePath),
-		ContentType: contentType
+		ContentType: contentType,
+		ACL: acl
 	});
 
 	upload.on('httpUploadProgress', progress => {
@@ -84,8 +86,20 @@ const s3 = {
 		},
 		baseURL: {
 			title: 'Base URL',
+			type: 'string'
+		},
+		acl: {
+			title: 'Access Control List (ACL)',
 			type: 'string',
-			require: false
+			enum: [
+				"private",
+				"public-read",
+				"public-read-write",
+				"authenticated-read",
+				"aws-exec-read",
+				"bucket-owner-read",
+				"bucket-owner-full-control"
+			]
 		}
 	}
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const url = require('url');
+const {URL} = require('url');
 const AWS = require('aws-sdk');
 
 const contentTypes = new Map([
@@ -48,7 +48,7 @@ const action = async context => {
 
 	const baseURL = context.config.get('baseURL');
 	if (baseURL) {
-		uploadURL = url.resolve(baseURL, objectKey);
+		uploadURL = new URL(objectKey, baseURL).href;
 	}
 
 	context.copyToClipboard(uploadURL);
@@ -92,13 +92,13 @@ const s3 = {
 			title: 'Access Control List (ACL)',
 			type: 'string',
 			enum: [
-				"private",
-				"public-read",
-				"public-read-write",
-				"authenticated-read",
-				"aws-exec-read",
-				"bucket-owner-read",
-				"bucket-owner-full-control"
+				'private',
+				'public-read',
+				'public-read-write',
+				'authenticated-read',
+				'aws-exec-read',
+				'bucket-owner-read',
+				'bucket-owner-full-control'
 			]
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -31,5 +31,11 @@
     "kap-plugin-test": "^0.5.0",
     "sinon": "^2.3.2",
     "xo": "*"
+  },
+  "ava": {
+    "files": [
+      "test/**/*",
+      "!test/fixtures/**/*"
+    ]
   }
 }

--- a/test/fixtures/s3-mock.js
+++ b/test/fixtures/s3-mock.js
@@ -4,13 +4,13 @@ const AWS = require('aws-sdk');
 class S3 {
 	upload(params) {
 		return {
-			on: (event, cb) => { },
+			on: () => { },
 			promise: () => Promise.resolve({
 				Location: `https://s3-${this._options.region}.amazonaws.com/${params.Bucket}/${params.Key}`
 			})
-		}
+		};
 	}
-};
+}
 
 const s3 = new S3();
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,8 @@ const config = {
 	region: 'eu-west-1',
 	accessKeyId: 'foo',
 	secretAccessKey: 'bar',
-	path: 'bucket/folder'
+	path: 'bucket/folder',
+	acl: 'public-read'
 };
 
 sinon.spy(s3, 'upload');
@@ -23,6 +24,7 @@ test('s3 upload parameters are correct', async t => {
 	t.is(s3UploadParams.Bucket, 'bucket');
 	t.is(s3UploadParams.Key, 'folder/unicorn.gif');
 	t.is(s3UploadParams.ContentType, 'image/gif');
+	t.is(s3UploadParams.ACL, 'public-read');
 });
 
 test('copies url to clipboard', async t => {


### PR DESCRIPTION
In my set-up the S3 bucket ACL is `private` which sets the same ACL on the uploaded files resulting in `403`s when requesting the generated URLs. 

This PR enables users to configure which ACL should be set on the uploaded S3 objects. By setting `"acl": "public-read"` in the config file, the uploaded files will be public even though the bucket policy is private.

Fixed some linter issues on the way and made tests pass again.