### PR TITLE
Add support for s3 compatible storage not hosted by AWS

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,14 @@ const action = async context => {
 
 	context.setProgress('Uploading…');
 
+	const custom_endpoint = new AWS.Endpoint(context.config.get('endpoint'))
+
 	const s3 = new AWS.S3({
 		region: context.config.get('region'),
 		accessKeyId: context.config.get('accessKeyId'),
-		secretAccessKey: context.config.get('secretAccessKey')
+		secretAccessKey: context.config.get('secretAccessKey'),
+		endpoint: custom_endpoint,
+		s3ForcePathStyle: context.config.get('pathStyle')
 	});
 
 	const split = context.config.get('path').split('/');
@@ -81,6 +85,18 @@ const s3 = {
 			type: 'string',
 			default: '',
 			required: true
+		},
+		endpoint: {
+			title: 'S3 Endpoint',
+			type: 'string',
+			default: '',
+			required: false
+		},
+		pathStyle: {
+			title: 'Use path style URLs',
+			type: 'boolean',
+			default: 'false',
+			required: false
 		},
 		baseURL: {
 			title: 'Base URL',

--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ const action = async context => {
 
 	context.setProgress('Uploading…');
 
-	const custom_endpoint = new AWS.Endpoint(context.config.get('endpoint'))
+	const customEndpoint = new AWS.Endpoint(context.config.get('endpoint'))
 
 	const s3 = new AWS.S3({
 		region: context.config.get('region'),
 		accessKeyId: context.config.get('accessKeyId'),
 		secretAccessKey: context.config.get('secretAccessKey'),
-		endpoint: custom_endpoint,
+		...(customEndpoint != '' ? {endpoint: customEndpoint} : {}),
 		s3ForcePathStyle: context.config.get('pathStyle')
 	});
 
@@ -50,7 +50,12 @@ const action = async context => {
 
 	const baseURL = context.config.get('baseURL');
 	if (baseURL) {
-		uploadURL = url.resolve(baseURL, objectKey);
+		if (context.config.get('pathStyle')) {
+			uploadURL = url.resolve(baseURL, bucket, objectKey);
+		} else {
+			uploadURL = url.resolve(baseURL, objectKey);
+		}
+
 	}
 
 	context.copyToClipboard(uploadURL);

--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ const action = async context => {
 
 	context.setProgress('Uploading…');
 
-	const customEndpoint = new AWS.Endpoint(context.config.get('endpoint'))
+	const customEndpoint = new AWS.Endpoint(context.config.get('endpoint'));
 
 	const s3 = new AWS.S3({
 		region: context.config.get('region'),
 		accessKeyId: context.config.get('accessKeyId'),
 		secretAccessKey: context.config.get('secretAccessKey'),
-		...(customEndpoint != '' ? {endpoint: customEndpoint} : {}),
+		...(customEndpoint !== '' ? {endpoint: customEndpoint} : {}),
 		s3ForcePathStyle: context.config.get('pathStyle')
 	});
 
@@ -51,13 +51,13 @@ const action = async context => {
 	const baseURL = context.config.get('baseURL');
 	if (baseURL) {
 		if (context.config.get('pathStyle')) {
-			uploadURL = url.resolve(baseURL, bucket, objectKey);
+			uploadURL = url.resolve(baseURL, bucket + "/" + objectKey);
 		} else {
 			uploadURL = url.resolve(baseURL, objectKey);
 		}
 
 	}
-
+ 
 	context.copyToClipboard(uploadURL);
 	context.notify('S3 URL copied to the clipboard');
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kap-s3",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Share on Amazon S3",
   "license": "MIT",
   "repository": "SamVerschueren/kap-s3",


### PR DESCRIPTION
Hi all,

I self-host my own S3 compatible storage using [Minio](https://min.io) and wanted to add support for using alternative upload endpoints into the plugin. I'm not used to javascript so please let me know where things could be improved or made better.

This should also work with Backblaze B2 and other cloud storage providers that provide an s3 compatible endpoint.